### PR TITLE
Fix wrong constant name

### DIFF
--- a/src/features/setup/components/index.tsx
+++ b/src/features/setup/components/index.tsx
@@ -10,7 +10,7 @@ const localTheme = (theme: DefaultTheme) => ({
   spacing: 5
 });
 
-const Test = () => {
+const Setup = () => {
   const navigate = useNavigate();
 
   return (
@@ -34,4 +34,4 @@ const Test = () => {
   );
 };
 
-export default Test;
+export default Setup;


### PR DESCRIPTION
I forgot to update the constant name in setup component, it does not make it work in a wrong way but it is better to have the proper name from the semantic point of view.